### PR TITLE
Fixing sha2 compilation issue.

### DIFF
--- a/dep/aes/sha2.h
+++ b/dep/aes/sha2.h
@@ -71,7 +71,7 @@
 #endif
 #else
   #include <stdint.h>
-  typedef int64_t sha2_64t;
+  typedef uint64_t sha2_64t;
   #if __WORDSIZE==64
     #define s_u64 ul
   #else


### PR DESCRIPTION
Compiler refused to convert unsigned long const to sha2_64t (long int)
so I changed sha2_64t to be unsigned (like it was on other platforms).